### PR TITLE
Don't prepend php executable to script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     ]
   },
   "scripts": {
-    "fix-cs": "@php ./vendor/bin/php-cs-fixer fix src -v --show-progress=estimating",
-    "run-tests": "@php ./vendor/bin/phpunit -c phpunit.xml.dist"
+    "fix-cs": "php-cs-fixer fix src -v --show-progress=estimating",
+    "run-tests": "phpunit -c phpunit.xml.dist"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
Composer will push the `vendor/bin` folder to the top of the `$PATH` variable before executing scripts, so the `php-cs-fixer` and `phpunit` from `vendor/bin` will be prioritised over anything installed globally anyway.

See [this page](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands).

![screenshot](https://i.imgur.com/UiFLYPl.png)