### PR TITLE
Add support for PHP CS Fixer 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": "^7.1||^8.0",
-    "friendsofphp/php-cs-fixer": "^2.7"
+    "friendsofphp/php-cs-fixer": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Fixer/Phpdoc/ForceFQCNFixer.php
+++ b/src/Fixer/Phpdoc/ForceFQCNFixer.php
@@ -9,14 +9,14 @@ use AdamWojs\PhpCsFixerPhpdocForceFQCN\Analyzer\NamespaceInfo;
 use AdamWojs\PhpCsFixerPhpdocForceFQCN\FQCN\FQCNTypeNormalizer;
 use PhpCsFixer\DocBlock\Annotation;
 use PhpCsFixer\DocBlock\DocBlock;
-use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-class ForceFQCNFixer implements DefinedFixerInterface
+class ForceFQCNFixer implements FixerInterface
 {
     /** @var \AdamWojs\PhpCsFixerPhpdocForceFQCN\FQCN\FQCNTypeNormalizer */
     private $normalizer;


### PR DESCRIPTION
Hi,
This adds support to PHP CS Fixer 3 while still working with PHP CS Fixer 2.9.
I only used a single `|` because it's enough. but I can use `||` to be more consistent with the PHP versions used above.
Thanks